### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -44,7 +44,7 @@ my $builder = $class->new(
         'Capture::Tiny'        => 0,
         'Test::Exception'      => 0,
         'Test::FailWarnings'   => 0,
-        'Test::Git'            => 0,
+        'Test::Requires::Git'  => 1.005,
         'Test::More'           => 0.94,
         'Test::Type'           => 0,
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,7 +13,7 @@ WriteMakefile
           'VERSION_FROM' => 'lib/App/GitHooks/Plugin/RubyCompile.pm',
           'PREREQ_PM' => {
                            'App::GitHooks' => 0,
-                           'Test::Git' => 0,
+                           'Test::Requires::Git' => 1.005,
                            'Test::Exception' => 0,
                            'Capture::Tiny' => 0,
                            'Test::FailWarnings' => 0,

--- a/t/10-run.t
+++ b/t/10-run.t
@@ -5,7 +5,7 @@ use warnings;
 
 use Capture::Tiny;
 use Test::Exception;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 use App::GitHooks::Test qw( ok_add_files ok_setup_repository );
@@ -45,7 +45,7 @@ my $tests =
 ];
 
 # Bail out if Git isn't available.
-has_git();
+test_requires_git();
 plan( tests => scalar( @$tests ) );
 
 foreach my $test ( @$tests )


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.
